### PR TITLE
[feature] 사용자 접근 검증을 위한 AOP Aspect 추가

### DIFF
--- a/src/main/java/backend/bookNote/book/controller/BookController.java
+++ b/src/main/java/backend/bookNote/book/controller/BookController.java
@@ -8,7 +8,6 @@ import backend.bookNote.book.dto.UserLikeBookDto;
 import backend.bookNote.book.service.BookService;
 import backend.bookNote.book.service.NaverSearchService;
 import backend.bookNote.book.vo.NaverResultVO;
-import backend.bookNote.note.dto.NoteResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
@@ -37,8 +36,8 @@ public class BookController {
     }
 
     @MutationMapping(name = "userLikeBook")
-    public String userLikeBook(@AuthenticationPrincipal UserCustom userCustom, @Argument(name = "UserLikeBookInput") UserLikeBookDto userLikeBookDto) {
-        return bookService.userBookLike(userCustom.getId(), userLikeBookDto);
+    public String userLikeBook(@Argument(name = "UserLikeBookInput") UserLikeBookDto userLikeBookDto) {
+        return bookService.userBookLike(userLikeBookDto);
     }
 
     @PostMapping("/share")

--- a/src/main/java/backend/bookNote/book/dto/UserLikeBookDto.java
+++ b/src/main/java/backend/bookNote/book/dto/UserLikeBookDto.java
@@ -1,9 +1,15 @@
 package backend.bookNote.book.dto;
 
+import backend.bookNote.common.asepct.HasUserId;
 import lombok.Data;
 
 @Data
-public class UserLikeBookDto {
+public class UserLikeBookDto implements HasUserId {
     private Long userId;
     private Long bookId;
+
+    @Override
+    public Long getUserId() {
+        return userId;
+    }
 }

--- a/src/main/java/backend/bookNote/book/service/BookService.java
+++ b/src/main/java/backend/bookNote/book/service/BookService.java
@@ -11,6 +11,7 @@ import backend.bookNote.book.repository.BookRepository;
 import backend.bookNote.book.repository.UserBookRepository;
 import backend.bookNote.book.vo.BookVO;
 import backend.bookNote.book.vo.NaverResultVO;
+import backend.bookNote.common.annotation.ValidateUserAccess;
 import backend.bookNote.common.exception.CustomError;
 import backend.bookNote.common.exception.CustomException;
 import backend.bookNote.note.domain.Note;
@@ -108,11 +109,9 @@ public class BookService {
         else throw new CustomException(CustomError.BOOK_NOT_FOUND);
     }
 
+    @ValidateUserAccess
     @Transactional
-    public String userBookLike(Long userId, UserLikeBookDto userLikeBookDto) {
-        if (!userId.equals(userLikeBookDto.getUserId())) {
-            throw new CustomException(CustomError.ACCESS_TOKEN_INVALID);
-        }
+    public String userBookLike(UserLikeBookDto userLikeBookDto) {
         UserBook userBook = userBookRepository.findByBookIdAndUserId(userLikeBookDto.getBookId(), userLikeBookDto.getUserId())
                 .orElseThrow(() -> new CustomException(CustomError.USERBOOK_NOT_FOUND));
 

--- a/src/main/java/backend/bookNote/common/annotation/ValidateUserAccess.java
+++ b/src/main/java/backend/bookNote/common/annotation/ValidateUserAccess.java
@@ -1,0 +1,11 @@
+package backend.bookNote.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateUserAccess {
+}

--- a/src/main/java/backend/bookNote/common/asepct/HasUserId.java
+++ b/src/main/java/backend/bookNote/common/asepct/HasUserId.java
@@ -1,0 +1,9 @@
+package backend.bookNote.common.asepct;
+
+/**
+ * userId 를 포함하는 DTO 를 검증하기 위해 userId 추출하려고 생성한 interface
+ */
+public interface HasUserId {
+    Long getUserId();
+
+}

--- a/src/main/java/backend/bookNote/common/asepct/UserValidationAspect.java
+++ b/src/main/java/backend/bookNote/common/asepct/UserValidationAspect.java
@@ -1,0 +1,42 @@
+package backend.bookNote.common.asepct;
+
+import backend.bookNote.auth.model.UserCustom;
+import backend.bookNote.common.exception.CustomError;
+import backend.bookNote.common.exception.CustomException;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.JoinPoint;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 메서드 실행 전에 사용자 접근 권한을 검증하는 Aspect
+ * 해당 Aspect 는 인증된 userId 가 method arguments 로 전달된 DTO 의 userId 와 일치하는지 확인합니다.
+ */
+@Aspect
+@Component
+public class UserValidationAspect {
+
+    @Before("@annotation(backend.bookNote.common.annotation.ValidateUserAccess)")
+    public void checkUserIdMatch(JoinPoint joinPoint) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // UserCustom 객체에서 userId 추출
+        UserCustom userCustom = (UserCustom) authentication.getPrincipal();
+        Long authenticatedUserId = userCustom.getId();
+
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            // HasUserId 를 implements 하는 DTO 에서 userId 추출
+            if (arg instanceof HasUserId) {
+                Long dtoUserId = ((HasUserId) arg).getUserId();
+                if (!authenticatedUserId.equals(dtoUserId)) {
+                    throw new CustomException(CustomError.ACCESS_TOKEN_INVALID);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/backend/bookNote/note/controller/NoteController.java
+++ b/src/main/java/backend/bookNote/note/controller/NoteController.java
@@ -34,8 +34,8 @@ public class NoteController {
     }
 
     @MutationMapping(name = "softDeleteNote")
-    public NoteResponseDto softDeleteNote(@AuthenticationPrincipal UserCustom userCustom, @Argument("NoteSoftDeleteDto") NoteSoftDeleteDto requestDto) {
-        return noteService.softDeleteNote(userCustom.getId(), requestDto);
+    public NoteResponseDto softDeleteNote(@Argument("NoteSoftDeleteDto") NoteSoftDeleteDto requestDto) {
+        return noteService.softDeleteNote(requestDto);
     }
 
     @MutationMapping(name = "hardDeleteNote")

--- a/src/main/java/backend/bookNote/note/dto/NoteSoftDeleteDto.java
+++ b/src/main/java/backend/bookNote/note/dto/NoteSoftDeleteDto.java
@@ -1,5 +1,6 @@
 package backend.bookNote.note.dto;
 
+import backend.bookNote.common.asepct.HasUserId;
 import lombok.*;
 
 @Builder
@@ -7,8 +8,13 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @Setter
-public class NoteSoftDeleteDto {
+public class NoteSoftDeleteDto implements HasUserId {
     private Long userId;
     private Long noteId;
     private boolean deleted;
+
+    @Override
+    public Long getUserId() {
+        return userId;
+    }
 }

--- a/src/main/java/backend/bookNote/note/service/NoteService.java
+++ b/src/main/java/backend/bookNote/note/service/NoteService.java
@@ -2,6 +2,7 @@ package backend.bookNote.note.service;
 
 import backend.bookNote.book.domain.UserBook;
 import backend.bookNote.book.repository.UserBookRepository;
+import backend.bookNote.common.annotation.ValidateUserAccess;
 import backend.bookNote.common.exception.CustomError;
 import backend.bookNote.common.exception.CustomException;
 import backend.bookNote.note.domain.Note;
@@ -49,11 +50,11 @@ public class NoteService {
         return note.toResponseDto();
     }
 
+    @ValidateUserAccess
     @Transactional
-    public NoteResponseDto softDeleteNote(Long userId, NoteSoftDeleteDto softDeleteDto) {
+    public NoteResponseDto softDeleteNote(NoteSoftDeleteDto softDeleteDto) {
         Note note = noteRepository.findByIdIncludingDeleted(softDeleteDto.getNoteId())
                 .orElseThrow(() -> new CustomException(CustomError.NOTE_NOT_FOUND));
-        validateUserAccess(note, userId);
 
         note.setIsDeleted(softDeleteDto.isDeleted());
         noteRepository.save(note);


### PR DESCRIPTION
AOP 를 활용하여 공통적인 사용자 접근 검증 로직을 모듈화했습니다.

- 메서드에 `@ValidateUserAccess` 어노테이션을 사용하면 인증된 사용자 token 의 ID와 DTO 내의 userId를 비교하여 검증할 수 있습니다.

- `@ValidateUserAccess` 어노테이션을 사용하고자 할 경우, 해당 메서드의 인자로 사용되는 DTO는 `HasUserId` 인터페이스를 구현해야 합니다.